### PR TITLE
To jest prawdziwe zarówno jeśli chodzi o mockistów jak i klasycystów

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,6 @@ final class ExampleTest extends TestCase
 ### Classical (Detroit school)
 
 - The unit is a single unit of behavior, it can be a few related classes.
-- Every test should be isolated from others. So it must be possible to invoke them in parallel or in any order.
 
 ```php
 final class TestExample extends TestCase


### PR DESCRIPTION
>Every test should be isolated from others. So it must be possible to invoke them in parallel or in any order.

To zdanie należy usunąć, ponieważ jest ono tak samo prawdziwe w stosunku do testów klasycystycznych jak i mockistycznych.

Każdy test, zarówno mockistyczny jak i klasycystyczny powinien być niezależny.

Mało tego, nawet jeśli nieumiejętnie zastosuję tą zasadę (czytaj: nie zastosuję), a więc otrzymam testy zależne, to nic to nie zmienia. Testy mockistyczne zależne dalej będą testami mockistycznymi, a testy klasycystyczne zależne, dalej będą testami klasycystycznymi. 